### PR TITLE
Lock background from scrolling when modal active and only scroll moda…

### DIFF
--- a/components/modal.vue
+++ b/components/modal.vue
@@ -79,6 +79,7 @@
 
         methods: {
             close () {
+                document.body.classList.remove('v-modal-overflow-hidden');
                 this.$modals.hide(this.name);
                 if (this.onClose) { this.onClose() }
                 this.$emit('close-modal', this.name);
@@ -86,14 +87,18 @@
 
             showModal() {
                 this.show = this.$modals.isActive(this.name);
-                this.centerModal();
-                if (this.onShow) { this.onShow() }
+                if (this.show) {
+                    document.body.classList.add('v-modal-overflow-hidden');
+
+                    this.centerModal();
+                    if (this.onShow) { this.onShow() }
+                }
             },
 
             centerModal() {
                 var modal = document.getElementById(this.id);
 
-                if(modal) {
+                if (modal) {
                     var margin = (window.innerWidth - modal.offsetWidth) / 2;
                     modal.style.marginLeft = margin + 'px';
                 }
@@ -108,11 +113,11 @@
         },
 
         mounted() {
-            if(this.width) {
+            if (this.width) {
                 this.style = this.style + 'width: ' + this.width + 'px;';
             }
 
-            if(this.height) {
+            if (this.height) {
                 this.style = this.style + 'height: ' + this.height + 'px;';
             }
         }
@@ -134,10 +139,10 @@
 
     .v-modal-wrapper {
         width:  100%;
-        height: 100%;
 
         .v-modal-content {
             margin:             0px auto;
+            margin-bottom:      5%;
             margin-top:         5%;
             width:              50%;
             background-color:   #fff;
@@ -184,6 +189,10 @@
                 padding-top:    0px;
             }
         }
+    }
+
+    .v-modal-overflow-hidden {
+        overflow: hidden !important;
     }
 
     /* Modal transition styles */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue2-modal",
-  "version": "1.1.0",
+  "version": "1.0.7",
   "description": "An easy to use vue 2 modal component for showing and hiding modals",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue2-modal",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "An easy to use vue 2 modal component for showing and hiding modals",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Closes #1 

This now locks the background from scrolling when modal is open. So when you scroll the modal to the very top or bottom, the body (background) will stay in place. Although no prop was introduced, this no longer scrolls by default unless the modal actually overflows the screen. 