### PR TITLE
Fixed no-scroll class removal.

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ export default {
              */
             hide(modalNames) {
                 /* Removes the scroll lock */
-                document.body.classList.remove('v-modal-overflow-hidden');
+                document.body.classList.remove('v-modal__no-scroll');
 
                 if (modalNames.constructor === Array) {
                     modalNames.forEach(modalName => {


### PR DESCRIPTION
When calling hide() manually, the function does not remove the proper css class and that leads to a screen with overflow hidden.