### PR TITLE
Allow click event propogation

### DIFF
--- a/components/modal.vue
+++ b/components/modal.vue
@@ -4,7 +4,7 @@
             @click.self="close('outer')"
             class="v-modal__mask"
             v-if="show">
-            <div class="v-modal__wrapper" :style="theme">
+            <div @click.self="close('outer')" class="v-modal__wrapper" :style="theme">
                 <div class="v-modal__content" :class="size" :id="id" :style="style">
                     <div class="v-modal__panel">
                         <div class="v-modal__heading">
@@ -167,6 +167,7 @@
 
         methods: {
             close (location) {
+                console.log(location);
                 if (location === 'outer' && !this.outerClose) return;
 
                 this.$modals.hide(this.name);

--- a/components/modal.vue
+++ b/components/modal.vue
@@ -167,7 +167,6 @@
 
         methods: {
             close (location) {
-                console.log(location);
                 if (location === 'outer' && !this.outerClose) return;
 
                 this.$modals.hide(this.name);

--- a/components/modal.vue
+++ b/components/modal.vue
@@ -1,11 +1,11 @@
 <template>
     <transition :name="'v-modal-' + transitionName">
         <div
-            @click.stop="close('outer')"
+            @click.self="close('outer')"
             class="v-modal__mask"
             v-if="show">
             <div class="v-modal__wrapper" :style="theme">
-                <div @click.stop class="v-modal__content" :class="size" :id="id" :style="style">
+                <div class="v-modal__content" :class="size" :id="id" :style="style">
                     <div class="v-modal__panel">
                         <div class="v-modal__heading">
                             <div class="v-modal__title"><slot name="header"></slot></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue2-modal",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "An easy to use vue 2 modal component for showing and hiding modals",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Allows click event propagation, but still only listens for 'closing' clicks on `v-modal__mask`